### PR TITLE
Adds form and update methods; closes #4

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -50,6 +50,8 @@ engines:
     checks:
       Controversial/CamelCaseClassName:
         enabled: false
+      Controversial/CamelCaseParameterName:
+        enabled: false
       Controversial/CamelCaseVariableName:
         enabled: false
 ratings:

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -109,6 +109,30 @@ class Multisearch_Widget extends \WP_Widget {
 			</div>';
 		echo '</div>';
 	}
+
+	/**
+	 * Back-end widget form
+	 *
+	 * @see WP_Widget::form()
+	 *
+	 * @param array $instance Previously saved values from database.
+	 */
+	public function form( $instance ) {
+		$instance = ''; // We can't have an empty method, for Reasons.
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @see WP_Widget::form()
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$old_instance = ''; // Discard old values.
+		return $new_instance;
+	}
 }
 
 /**


### PR DESCRIPTION
This adds a very basic form() and update() method to the widget. All of this plugin's content is static, so there isn't an internal need for these, but other plugins on the network also use that form (for setting visibility and other restrictions) - so to conform with best practices and play nice with others, we're adding them here.

Closes #4 