### PR TITLE
Adds limiters to article tab; closes #9

### DIFF
--- a/templates/tab_articles.html
+++ b/templates/tab_articles.html
@@ -1,5 +1,5 @@
 <p>Search individual articles</p>
-<form action="https://search.ebscohost.com/login.aspx" method="get">
+<form action="https://search.ebscohost.com/login.aspx" id="eds" method="get">
 	<input name="direct" value="true" type="hidden">
 	<input name="scope" value="site" type="hidden">
 	<input name="site" value="eds-live" type="hidden">
@@ -7,8 +7,9 @@
 	<input name="custid" value="s8978330" type="hidden">
 	<input name="profile" value="eds" type="hidden">
 	<input name="groupid" value="main" type="hidden">
+	<input name="bquery" value="" type="hidden">
 	<div class="row">
-		<input type="text" name="bquery" placeholder="Search journal articles...">
+		<input type="text" name="uquery" placeholder="Search journal articles...">
 		<input type="submit">
 	</div>
 	<select name="limit">
@@ -18,3 +19,9 @@
 	</select>
 </form>
 <p>Also try: Browse journals by title, View article databases</p>
+<script type="text/javascript">
+jQuery('form#eds').on('submit', function(){
+	// Concatenate limiter and search query
+	this.bquery.value = (this.limit.value + this.uquery.value).replace(/"/g, '&quot;');
+});
+</script>

--- a/templates/tab_articles.html
+++ b/templates/tab_articles.html
@@ -11,5 +11,10 @@
 		<input type="text" name="bquery" placeholder="Search journal articles...">
 		<input type="submit">
 	</div>
+	<select name="limit">
+		<option value="" selected="selected">Keyword</option>
+		<option value="TI ">Title</option>
+		<option value="AU ">Author</option>
+	</select>
 </form>
 <p>Also try: Browse journals by title, View article databases</p>


### PR DESCRIPTION
What:

- This adds a dropdown to the EDS form to enable searching in three modes: Keyword (default), Title, and Author.

Why:

- The UI mockups call for an ability to perform different types of searches. These are the three types currently possible, so it made sense to preserve that setup.

How:

- Using an example from the EBSCO Wiki (http://edswiki.ebscohost.com/Search_Box:_Limiters_as_Check_Boxes) I added a select/option construct to the form. This is then parsed via Javascript when the form is submitted, and the relevant value (``, `TI `, or `AU `) is prepended to the search query string.

Caveats:

- While this JS-based approach is the same one we use now, and is the one recommended by EBSCO, it breaks when javascript is not enabled. The fallback behavior is that all searches become keyword searches - so the tool still functions, but additional options aren't useful. **It might be useful to just send a simple search form without the select/option construct, and enable that only if javascript is available.**
- The user lands in EDS with a limiter code prepended to their search string, rather than in an actual Title or Author search. This is the behavior that EBSCO's sample code provides, so I know I haven't messed anything up. It is also the behavior we provide currently - so it isn't a regression. **An alternative might be to try and pass in parameters that actually provoke the right search form, but I haven't seen those documented anywhere.**