### PR TITLE
Fixes file comment for class file. Closes #20

### DIFF
--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -1,16 +1,9 @@
 <?php
 /**
- * Plugin Name: Multisearch Widget
- * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
- * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 0.2.0
- * Author: Matt Bernhardt
- * Author URI: https://github.com/matt-bernhardt
- * License: GPL2
+ * Class that defines the multisearch widget.
  *
  * @package Multisearch Widget
- * @author Matt Bernhardt
- * @link https://github.com/MITLibraries/wp-multisearch-widget
+ * @since 0.3.0
  */
 
 namespace mitlib;


### PR DESCRIPTION
The duplication noted in #20 comes from a file comment in `class-multisearch-widget.php` that repeats content used by Wordpress to assemble the list of available plugins. Removing this information causes the plugin to appear only once.