### PR TITLE
Sets initial state to always show 'All' panel

### DIFF
--- a/wp-multisearch-widget.js
+++ b/wp-multisearch-widget.js
@@ -29,7 +29,7 @@ jQuery( document ).ready(function() {
 	// Call Responsive Tabs plugin.
 	$tabs.responsiveTabs({
 		rotate: false,
-		startCollapsed: 'accordion',
+		startCollapsed: false,
 		collapsible: false,
 		setHash: true
 	});


### PR DESCRIPTION
This closes [DI-319](https://mitlibraries.atlassian.net/browse/DI-319)

As of 3:45 on 5/11 this is on -dev for evaluation. It changes the way in which the responsive tabs plugin is called so that there's a default panel open on all displays.