### PR TITLE
[WIP] Converts book target switcher to more accessible approach; closes DI-311

### DIFF
--- a/templates/tab-books.php
+++ b/templates/tab-books.php
@@ -8,14 +8,12 @@
  */
 
 ?>
+<ul id="books-target" class="select-books-target">
+	<li><button class="button-search" data-target="localbooks" data-default="true">at MIT</button></li>
+	<li><button class="button-search" data-target="worldcat">libraries worldwide</button></li>
+</ul>
 <p>Books, ebooks, audio books, music, and videos</p>
 <div class="panel"></div>
-<ul id="books-target">
-	<li><label><input type="radio" name="books-target" value="localbooks">at MIT</label></li>
-	<li>
-		<label><input type="radio" name="books-target" value="worldcat" checked="checked">libraries worldwide</label>
-	</li>
-</ul>
 <p>Also try:
 	<a href="/barton">Barton Classic</a>,
 	<a href="/barton-theses">Theses</a>, or
@@ -32,15 +30,15 @@ function loadBooksForm(choice,panel) {
 
 jQuery( document ).ready( function() {
 	// Set default form to Worldcat
-	var btarget = jQuery("#books-target input[name=books-target]:checked").val();
+	var btarget = jQuery("#books-target .button-search[data-default='true']").data('target');
 	var bpanel = jQuery("#search-books .panel");
 
 	// Load default form (set in markup)
 	loadBooksForm( btarget, bpanel );
 
 	// Detect target change, swap forms as needed
-	jQuery("#books-target input[name=books-target]").on('change',function() {
-		loadBooksForm( this.value, bpanel );
+	jQuery("#books-target .button-search").on('click',function() {
+		loadBooksForm( jQuery(this).data('target'), bpanel );
 	});
 
 });


### PR DESCRIPTION
This should resolve DI-311 through the following changes:
- Moves book switcher before the book form in source order (following a11y best practices - having it later in source order is problematic)
- Converts book switcher from using `input` elements to `button` elements. Inputs must be inside a form, while buttons are allowed anywhere (these are outside of a form element)
- Updates javascript that listens for switcher interaction to use data attributes rather than input values (which are no longer present)

This merging this branch will probably require massaging with styles introduced by `frances/enhance/style-tabs`. A generic button style will be needed, as well as an active class.