### PR TITLE
Tweaks Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,8 @@ before_script:
     - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
     # Hop into CodeSniffer directory.
     - cd php-codesniffer
+    # Checkout pre 3.x version
+    - git checkout tags/2.9.0
     # Set install path for WordPress Coding Standards.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
     - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards


### PR DESCRIPTION
Recent operations on Travis have been failing because our test setup has been to check out the latest version of PHP_CodeSniffer. With the recent release of phpcs 3.0, however, this has broken all of our tests. 

This change adjusts our Travis setup to explicitly use the last release on the 2.x branch, while I work out how 3.x needs to be called.