### PR TITLE
Adds banner_text feature to plugin

### DIFF
--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -68,7 +68,7 @@ class Multisearch_Widget extends \WP_Widget {
 		echo '<noscript><p>It appears that your browser does not support javascript.</p>';
 		include( 'templates/form_nojs.html' );
 		echo '</noscript>';
-		echo '<div id="multisearch" class="wrap-search nojs">';
+		echo '<div id="multisearch" class="' . esc_attr( $this->widgetClasses( $instance ) ) . ' nojs">';
 		echo '<h2 id="searchtabsheader" class="sr">Search the MIT libraries</h2>
 			<ul id="search_tabs_nav" role="navigation" aria-labelledby="searchtabsheader">
 			<li><a href="#search-all"><span>All</span></a></li>
@@ -88,6 +88,23 @@ class Multisearch_Widget extends \WP_Widget {
 		echo '<div id="search-more">';
 		include( 'templates/tab-more.php' );
 		echo '</div>';
+		if ( $instance['banner_text'] ) {
+			$allowed = array(
+				'a' => array(
+					'class' => array(),
+					'href' => array(),
+					'style' => array(),
+				),
+				'p' => array(
+					'class' => array(),
+					'style' => array(),
+				),
+				'style' => array(),
+			);
+			echo '<div class="wrap-banner-text no-js-hidden">';
+			echo wp_kses( $instance['banner_text'], $allowed );
+			echo '</div>';
+		}
 		echo '</div>';
 
 		// Google analytics script (this has to be here so we can pull GA property from server).
@@ -111,6 +128,7 @@ class Multisearch_Widget extends \WP_Widget {
 	 */
 	public function form( $instance ) {
 		$ga_property = $instance['ga_property'];
+		$banner_text = $instance['banner_text'];
 		?>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'ga_property' ) ); ?>">
@@ -122,6 +140,19 @@ class Multisearch_Widget extends \WP_Widget {
 				type="text"
 				name="<?php echo esc_attr( $this->get_field_name( 'ga_property' ) ); ?>"
 				value="<?php echo esc_html( $ga_property ); ?>">
+		</p>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'banner_text' ) ); ?>">
+				<?php esc_attr_e( 'Banner Text (limited HTML allowed)' ); ?>
+			</label>
+			<textarea
+				class="widefat"
+				id="<?php echo esc_attr( $this->get_field_id( 'banner_text' ) ); ?>"
+				type="text"
+				rows="5"
+				name="<?php echo esc_attr( $this->get_field_name( 'banner_text' ) ); ?>"><?php
+				echo esc_html( $banner_text );
+			?></textarea>
 		</p>
 		<?php
 	}
@@ -137,6 +168,21 @@ class Multisearch_Widget extends \WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 		$instance['ga_property'] = $new_instance['ga_property'];
+		$instance['banner_text'] = $new_instance['banner_text'];
 		return $instance;
+	}
+
+	/**
+	 * The classes applied to the widget depend on if the banner_text property
+	 * is set.
+	 *
+	 * @param array $instance The widget being rendered.
+	 */
+	private function widgetClasses( $instance ) {
+		$class = 'wrap-search';
+		if ( $instance['banner_text'] ) {
+			$class = 'wrap-search-banner';
+		}
+		return $class;
 	}
 }

--- a/wp-multisearch-widget.css
+++ b/wp-multisearch-widget.css
@@ -7,6 +7,12 @@
 	background-color: linear-gradient(45deg,#5889c2 0,#3fa0c9 100%);
 	padding: 30px 3%;
 }
+.wrap-search-banner {
+	background-color: #338bc5;
+	background-color: linear-gradient(45deg,#5889c2 0,#3fa0c9 100%);
+	padding: 30px 3% 60px 3%;
+	position: relative;
+}
 .r-tabs-tab {
 	padding: .25rem 1.3rem;
 	border-radius: 3px 3px 0 0;
@@ -15,7 +21,7 @@
 	background-color: transparent;
 }
 .r-tabs-state-active {
- 	background-color: #fff;
+	background-color: #fff;
  }
 .r-tabs-state-default .r-tabs-anchor, 
 .r-tabs-accordion-title .r-tabs-anchor {
@@ -23,15 +29,15 @@
 }
 .r-tabs-accordion-title .r-tabs-anchor {
 	display: block;
-  padding: .75rem 3%;
-  background: #ddd url('i/down-caret.png') no-repeat 97% center;  
-  background-color: rgba(255,255,255,.3);
-  font-weight: 600;
-  border-bottom: 2px solid #338bc5;
+	padding: .75rem 3%;
+	background: #ddd url('i/down-caret.png') no-repeat 97% center;  
+	background-color: rgba(255,255,255,.3);
+	font-weight: 600;
+	border-bottom: 2px solid #338bc5;
 }
 .r-tabs-accordion-title.r-tabs-state-active .r-tabs-anchor {
-  background-color: #fff;
-  border-bottom: 0;
+	background-color: #fff;
+	border-bottom: 0;
 }
 .r-tabs-accordion-title.r-tabs-state-active .r-tabs-anchor,
 .r-tabs-tab.r-tabs-state-active .r-tabs-anchor {
@@ -43,7 +49,7 @@
 	text-decoration: none;
 }
 .r-tabs .r-tabs-panel {
-  padding: 10px 3% 15px 3%;
+	padding: 10px 3% 15px 3%;
 }
 .r-tabs-panel.r-tabs-state-active {
 	background-color: #fff;
@@ -61,13 +67,13 @@
 	margin-bottom: 0.4rem;
 	margin-top: 0.2rem;
 	width: 99%;
-  padding: 6px 12px;
-  background-image: none;
-  border: 1px solid #ccc;
-  border-radius: 2px;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.2) inset;
-  font-size: 1rem;	
+	padding: 6px 12px;
+	background-image: none;
+	border: 1px solid #ccc;
+	border-radius: 2px;
+	background-color: #fff;
+	box-shadow: 0 0 3px rgba(0, 0, 0, 0.2) inset;
+	font-size: 1rem;	
 }
 .r-tabs .field-text:focus {
 	border: 1px solid #338bc5;
@@ -78,25 +84,25 @@
 	position: relative;
 }
 .r-tabs .field-select {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  width: 100%;
-  margin-bottom: .4rem;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	width: 100%;
+	margin-bottom: .4rem;
 	border: none;
-  border-radius: 2px;
-  background: #ddd url('i/down-arrow.png') no-repeat 97% center;
-  padding: 8px 30px 8px 15px;
-  color: #555;
+	border-radius: 2px;
+	background: #ddd url('i/down-arrow.png') no-repeat 97% center;
+	padding: 8px 30px 8px 15px;
+	color: #555;
 }
 .r-tabs .field-select::-ms-expand {
-  display: none;
+	display: none;
 }
 .r-tabs .field-select:hover, 
 .r-tabs .field-select:focus {
 	background-color: #D6E8F4;
 }
 .r-tabs input[type="radio"] {
-    margin-right: 7px;
+		margin-right: 7px;
 }
 .r-tabs .button-search {
 	-webkit-appearance: none;
@@ -111,15 +117,15 @@
 }
 .r-tabs .button-search:hover, 
 .r-tabs .button-search:focus {
-  border-color: #0EA6EC;
-  background-color: #0EA6EC;
-  background-image: none;
-  color: #fff;
-  text-decoration: none;
+	border-color: #0EA6EC;
+	background-color: #0EA6EC;
+	background-image: none;
+	color: #fff;
+	text-decoration: none;
 }
 .r-tabs .select-books-target li {
 	display: inline-block;
-  margin-bottom: .5rem;
+	margin-bottom: .5rem;
 	margin-right: 1.5rem;
 }
 .r-tabs .also {
@@ -151,68 +157,92 @@
 .wrap-askus .askus-name:after {
 	content: ":";
 }
+.wrap-banner-text {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	background-color: #9c3273;
+	padding: 5px 15px;
+	color: #E5CEDC;
+	font-size: 12px;
+	font-weight: 600;
+	text-align: right;
+}
+.wrap-banner-text p {
+		margin-bottom: 0 !important;
+}
+.wrap-banner-text a {
+	color: #fff;
+}
+.wrap-banner-text a:after {
+	content: ' » ';
+}
+.wrap-banner-text a:hover {
+	color: #fff;
+}
 
 @media only screen and (min-width: 768px) {
 
-  .r-tabs .r-tabs-panel {
-    padding-top: 20px;
-  }
-  .r-tabs .field-text {
-  	display: inline-block;
-  	width: 70%;
-  }
-  .r-tabs .field-wrap-select {
+	.r-tabs .r-tabs-panel {
+		padding-top: 20px;
+	}
+	.r-tabs .field-text {
+		display: inline-block;
+		width: 70%;
+	}
+	.r-tabs .field-wrap-select {
 		display: inline-block;
 		width: auto;
-  }
-  .r-tabs .field-select {
+	}
+	.r-tabs .field-select {
 		width: auto;
 		background: #ddd url('i/down-arrow.png') no-repeat 92% center;
-  }
-  .r-tabs .button-search {
-  	display: inline-block;
+	}
+	.r-tabs .button-search {
+		display: inline-block;
 		width: auto;
-  }
-  .r-tabs .wrap-flex {
-    display: flex;
-    align-items: baseline;
-  }
-  .r-tabs .flex-left {
-    flex: 3;
-  }
-  .r-tabs .flex-right {
-    margin-top: .25rem;
-  }
-  .r-tabs .flex-left-inner {
-    display: flex;
-    align-items: baseline;
-  }
-  .r-tabs .field-text {
-    width: 99%;
-    margin-right: .5rem;
-  }
-  .r-tabs .field-wrap-select {
-    margin-right: .5rem;
-  }
-  .r-tabs .col-1, 
-  .r-tabs .col-2, 
-  .r-tabs .col-3 {
-    display: inline-block;
-    vertical-align: top;
-    width: 37%;
-    margin-right: 1%;
-  }
-  .r-tabs .col-3 {
-  	width: 15%;
-    margin-right: 0;
-  }
-  .askus-link {
-  	padding: 36px 0 0 0;
-  	background: #fff url('i/askus-bubble.png') no-repeat center top;
-  	text-align: center;
-  }
-  .wrap-askus span {
-  	display: block;
-  }
+	}
+	.r-tabs .wrap-flex {
+		display: flex;
+		align-items: baseline;
+	}
+	.r-tabs .flex-left {
+		flex: 3;
+	}
+	.r-tabs .flex-right {
+		margin-top: .25rem;
+	}
+	.r-tabs .flex-left-inner {
+		display: flex;
+		align-items: baseline;
+	}
+	.r-tabs .field-text {
+		width: 99%;
+		margin-right: .5rem;
+	}
+	.r-tabs .field-wrap-select {
+		margin-right: .5rem;
+	}
+	.r-tabs .col-1, 
+	.r-tabs .col-2, 
+	.r-tabs .col-3 {
+		display: inline-block;
+		vertical-align: top;
+		width: 37%;
+		margin-right: 1%;
+	}
+	.r-tabs .col-3 {
+		width: 15%;
+		margin-right: 0;
+	}
+	.askus-link {
+		padding: 36px 0 0 0;
+		background: #fff url('i/askus-bubble.png') no-repeat center top;
+		text-align: center;
+	}
+	.wrap-askus span {
+		display: block;
+	}
 }
 


### PR DESCRIPTION
This change is in response to [DI-347](https://mitlibraries.atlassian.net/browse/DI-347), which calls for an ability to retain the existing purple messaging banner at the bottom of the search UI.

In porting this feature, it adds a text area to the widget options form, allowing a limited set of markup for use by site maintainers: currently just `p` and `a` tags. If maintainers add anything in that field, the banner is added upon render. If the field is blank, the banner disappears.