### PR TITLE
Switches the tabs analytics to use ga() but under a different site name

### DIFF
--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -113,9 +113,8 @@ class Multisearch_Widget extends \WP_Widget {
 			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','https://www.google-analytics.com/analytics.js','discovery');
-			discovery('create', '" . esc_attr( $instance['ga_property'] ) . "', 'auto');
-			discovery('send', 'pageview');
+			})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+			ga('create', '" . esc_attr( $instance['ga_property'] ) . "', 'auto', {'name':'discovery'});
 		</script>";
 	}
 

--- a/wp-multisearch-widget.js
+++ b/wp-multisearch-widget.js
@@ -11,7 +11,7 @@ function logSearch(element) {
 	search.type = jQuery( element ).find( "select" ).find(":selected").text();
 
 	// Send search details to analytics
-	discovery('send', {
+	ga('discovery.send', {
 		hitType: 'event',
 		eventCategory: 'Wordpress',
 		eventAction: 'Search',


### PR DESCRIPTION
While early testing seemed to indicate that the analytics approach in this plugin was valid, early returns from production indicate that we are missing a significant number of searches. We came to this conclusion by comparing the searches reported via the `discovery()` function in this plugin against the page traffic being reported by the Bento app.

To fix this issue, this branch changes how GA is being implemented. Until now, we've tried to avoid collisions with the primary GA account by instantiating GA under a different function name (discovery() instead of ga()). However, another syntax is possible, using site name parameters. This is the how the parent theme reports traffic back to both the Libraries' GA profile and the overall MIT GA profile.