### PR TITLE
Adds linker plugin to analytics

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,6 +19,8 @@ engines:
         enabled: false
       PSR1 Files SideEffects FoundWithSymbols:
         enabled: false
+      PSR1 Methods CamelCapsMethodName NotCamelCaps:
+        enabled: false
       PSR2 Classes ClassDeclaration OpenBraceNewLine:
         enabled: false
       PSR2 ControlStructures ControlStructureSpacing SpacingAfterOpenBrace:
@@ -49,6 +51,8 @@ engines:
     enabled: true
     checks:
       Controversial/CamelCaseClassName:
+        enabled: false
+      Controversial/CamelCaseMethodName:
         enabled: false
       Controversial/CamelCaseParameterName:
         enabled: false

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.1.1
+ * Version: 1.2.0
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a new field to the widget configuration form for "Linked Domains". If provided, this will:
1) Cause the integrated GA call to include the Linker plugin
2) Check all form submissions from this widget for whether the searched target is on the list of linked domains.
3) If the search target is on the list, it will call the `decorate` method provided by the Linker plugin, which will add URL parameters to preserve session information between the WordPress site and the target server.

The heart of the change is https://github.com/MITLibraries/wp-multisearch-widget/pull/48/files#diff-ad61296cf41e5395d01478765ec7042dR52 - the call to decorate the submitted form.

#### Helpful background context (if appropriate)
While we have combined GA accounts for the discovery environment for several applications, users moving between these tools are not counted as one user without decorating cross-domain links. Achieving this for HTML links is handled automatically by the Linker plugin, but forms need separate handling - which this PR provides.

#### How can a reviewer manually see the effects of these changes?
1. Enable recording in the Google Tag Assistant plugin on Chrome (this _must_ be done before you visit the homepage)
2. Visit the -dev site home page
3. Conduct a search against your preferred target
4. When you reach the results page, stop recording in Google Tag Assistant, and view the report for the Discovery profile. You should see a list of every page you visited during the session, with only one indication of a new session being started.

Compare the above workflow on the dev server to what happens in production, where the Google Tag Assistant report will indicate that a new session is begun every time the user changes domains - even if the domains in question are all reporting to the same GA property.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
New "Linked Domains" configuration field
![image](https://user-images.githubusercontent.com/1403248/30712778-27d8711c-9edb-11e7-9c72-3f0ca6b262cf.png)

Resulting markup
![image](https://user-images.githubusercontent.com/1403248/30712805-446dfae0-9edb-11e7-8c4b-32d8f6fcd1e5.png)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
