### PR TITLE
Listens for input event to allow pasting into search on mobile devices

### DIFF
--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -49,7 +49,7 @@ class Multisearch_Widget extends \WP_Widget {
 			'multisearch-js',
 			plugin_dir_url( __FILE__ ) . 'wp-multisearch-widget.js',
 			array( 'responsivetabs-js' ),
-			'0.1.0',
+			'1.1.1',
 			false
 		);
 		// Finally, we enquey only this plugin's javascript (which brings everything else in).

--- a/wp-multisearch-widget.js
+++ b/wp-multisearch-widget.js
@@ -30,7 +30,7 @@ function preventSearch(textField,button) {
 			$( button ).prop('disabled', false); 
 	}		
 
-	$( textField ).keyup(function() {
+	$( textField ).on('keyup input', function() {
 		if($(this).val().trim().length !=0 ) {			
 			$( button ).prop('disabled', false); 
 		} else {

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds an additional event to the listener which enables the "Search" button.

Originally we just detected the `keyup` event, but that doesn't get triggered when someone pastes content into a search field on mobile devices. The solution is to also detect the `input` event.

In order to ensure that the new Javascript is loaded upon deploy, we update the cache-busting call to `wp_register_script`. Otherwise browsers will only very slowly clear their caches and get the fix.

#### How can a reviewer manually see the effects of these changes?
Load the front page on the front page, and try pasting something into a search field (or selecting something from the suggestions populated by your mobile browser). Note that the submit button remains disabled.

Now load the front page on the test server, and repeat the same actions. Note that the submit button activates as expected.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-523

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
