### PR TITLE
Adds version string to style loader

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/NTI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated plugins, themes, or libraries?
+YES | NO
+
+#### Requires change to deploy process?
+YES | NO

--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -96,18 +96,19 @@ class Multisearch_Widget extends \WP_Widget {
 			'multisearch-js',
 			plugin_dir_url( __FILE__ ) . 'wp-multisearch-widget.js',
 			array( 'responsivetabs-js' ),
-			'1.1.1',
+			'1.3.0',
 			false
 		);
 		// Finally, we enquey only this plugin's javascript (which brings everything else in).
 		wp_enqueue_script( 'multisearch-js' );
 
 		// Register / enqueue styles.
-		wp_register_style( 'responsivetabs-css', plugin_dir_url( __FILE__ ) . 'libs/responsive-tabs.css' );
+		wp_register_style( 'responsivetabs-css', plugin_dir_url( __FILE__ ) . 'libs/responsive-tabs.css', '', '1.6.1' );
 		wp_register_style(
 			'multisearch-tabs',
 			plugin_dir_url( __FILE__ ) . 'wp-multisearch-widget.css',
-			array( 'responsivetabs-css' )
+			array( 'responsivetabs-css' ),
+			'1.3.0'
 		);
 		wp_enqueue_style( 'multisearch-tabs' );
 

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This extends our use of version strings in asset loading as a way of cache busting. The original plugin used versions to load the responsiveTabs javascript, but ended there. Internal assets were loaded without version strings.

This PR extends the technique to other plugin assets. Down the road we should look into streamlining how we implement this technique (probably by defining a PHP constant that would store the version string once and load it everywhere), but that's work for a future time.

#### Helpful background context (if appropriate)
From https://codex.wordpress.org/Function_Reference/wp_register_style
```
$ver
(string|boolean) (optional) String specifying the stylesheet version number, if it has one. This parameter is used to ensure that the correct version is sent to the client regardless of caching, and so should be included if a version number is available and makes sense for the stylesheet. The version is appended to the stylesheet URL as a query string, such as ?ver=3.5.1. By default, or if false, the WordPress version string is used. If null nothing is appended to the URL.
Default: false
```

#### How can a reviewer manually see the effects of these changes?
Look at the front page on the development server, and check that the plugin assets are loaded with a querystring such as `wp-multisearch-widget.css?ver=1.3.0`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-415

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
