### PR TITLE
Updates WorldCat search preparation after WorldCat migration

### DIFF
--- a/templates/tab-books.php
+++ b/templates/tab-books.php
@@ -81,21 +81,20 @@ function setBartonSearch(form) {
 
 function setWorldcatSearch(form) {
 	// Set action
-	form.action = 'https://mit.worldcat.org/search';
+	form.action = 'https://mit.on.worldcat.org/search';
 
 	// Load hidden fields
 	jQuery(form).find(".hidden")
 		.empty()
-		.append('<input type="hidden" name="qt" value="wc_org_mit">')
-		.append('<input type="hidden" name="qt" value="affiliate">')
-		.append('<input type="hidden" name="q">');
+		.append('<input type="hidden" name="queryString">');
 
-	// Build search field
-	var limit = '';
+	// Transfer search string to actual field
+	form.queryString.value = form.search.value.trim();
+
+	// Build search field with title/author syntax
 	if ( form.limit.value !== '' ) {
-		limit = form.limit.value.toLowerCase() + ':';
+		form.queryString.value = form.limit.value.toLowerCase() + ':(' + form.queryString.value + ')';
 	}
-	form.q.value = (limit + form.search.value).trim();
 }
 
 jQuery( document ).ready( function() {

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.3.0
+ * Version: 1.4.0
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This updates how searches are manipulated on the way to WorldCat, now that we've upgraded what instance of the WorldCat service we're using. Specifically, we dropped two unused fields that were hidden, changed the domain to which we refer traffic, and alter the syntax for title and author searches (it was just via prefixes, but is now something like `ti:(foo)` or `au:(name)`

#### Helpful background context (if appropriate)
The search forms in this plugin are only skeletons until the form is submitted - at which point target-specific hidden fields are created, and the search string itself is moved over to a field that's specific to each target.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to the staging server for review

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-540

#### Todo:
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
