### PR TITLE
Tries passing e element specifically within preventSearch()

### DIFF
--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -96,7 +96,7 @@ class Multisearch_Widget extends \WP_Widget {
 			'multisearch-js',
 			plugin_dir_url( __FILE__ ) . 'wp-multisearch-widget.js',
 			array( 'responsivetabs-js' ),
-			'1.3.0',
+			'1.4.1',
 			false
 		);
 		// Finally, we enquey only this plugin's javascript (which brings everything else in).

--- a/wp-multisearch-widget.js
+++ b/wp-multisearch-widget.js
@@ -30,7 +30,7 @@ function preventSearch(textField,button) {
 			$( button ).prop('disabled', false); 
 	}		
 
-	$( textField ).on('keyup input', function() {
+	$( textField ).on('keyup input', function(e) {
 		if($(this).val().trim().length !=0 ) {			
 			$( button ).prop('disabled', false); 
 		} else {

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This fixes a JavaScript problem that is throwing errors in users' consoles and in Sentry. The problem is that the function we use to disable the search form doesn't correctly pass along the event information. This throws a problem when the browser tries to use that event to prevent the default behavior (form submission).

This PR fixes that problem by actually providing the event information, preventing the error from occurring.

#### Helpful background context (if appropriate)
Earlier attempts at diagnosis made is sound as if this problem prevented form submission via keyboard, but looking this afternoon shows this not to be true. The problem is noisy, but doesn't affect site behavior (thankfully).

#### How can a reviewer manually see the effects of these changes?
In production, open a browser console while on the front page, and tab-navigate into the search field. Observe the following error in the console: `Uncaught ReferenceError: e is not defined`.

Compare this to staging, where no such error occurs.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-521
- https://sentry.io/share/issue/f0ddefcfe8134ba0a61da4d3be8241a8/

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
