### PR TITLE
UXWS-947 Updates to 'More...' tab links

### DIFF
--- a/templates/tab-more.php
+++ b/templates/tab-more.php
@@ -15,6 +15,7 @@
 			<li><a href="/barton-reserves">Course reserves</a></li>
 			<li><a href="/barton-theses">MIT Theses</a></li>
 			<li><a href="https://dspace.mit.edu">DSpace@MIT</a></li>
+			<li><a href="https://archivesspace.mit.edu/">ArchivesSpace</a></li>
 			<li><a href="http://libraries.mit.edu/experts/">Search tools by subject</a></li>
 			<li><a href="/search">More search options: images, data, etc.</a></li>
 		</ul>
@@ -22,7 +23,7 @@
 	<div class="col col-2">
 		<h3 class="header-col">Other useful tools</h3>
 		<ul>
-			<li><a href="/libx">LibX browser plug-in</a></li>
+			<li><a href="https://libraries.mit.edu/worldcat">WorldCat</a></li>
 			<li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT</a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
## Status
`needs review`

#### What does this PR do?
Adds 'ArchivesSpace' link and changes 'LibX browser plug-in' link to 'WorldCat' in 'More...' tab.

#### How can a reviewer manually see the effects of these changes?
The changes are currently live in staging: https://libraries-stage.mit.edu. Click the 'More...' tab and confirm that the 'ArchivesSpace' link appears after 'DSpace@MIT', and that the 'WordCat' appears above 'Google Scholar for MIT'.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-947

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES (updates this plugin, but no other dependencies)

#### Requires change to deploy process?
NO
