### PR TITLE
Enable switching between library vendors

### DIFF
--- a/class-multisearch-widget.php
+++ b/class-multisearch-widget.php
@@ -79,6 +79,20 @@ class Multisearch_Widget extends \WP_Widget {
 	 * @link https://developer.wordpress.org/reference/classes/wp_widget/
 	 */
 	public function widget( $args, $instance ) {
+		// Identify which templates are needed based on instance variable.
+		$all_template = 'templates/tab-all-eds.php';
+		$books_template = 'templates/tab-books-eds.php';
+		$articles_template = 'templates/tab-articles-eds.php';
+		$articles_tab_name = 'Journals + articles';
+		$more_template = 'templates/tab-more-eds.php';
+		if ( 'alma' == $instance['targets'] ) {
+			$all_template = 'templates/tab-all-alma.php';
+			$books_template = 'templates/tab-books-alma.php';
+			$articles_template = 'templates/tab-articles-alma.php';
+			$articles_tab_name = 'Articles + chapters';
+			$more_template = 'templates/tab-more-alma.php';
+		}
+
 		// Strip initial arguments.
 		$args = null;
 
@@ -119,22 +133,24 @@ class Multisearch_Widget extends \WP_Widget {
 		echo '<div id="multisearch" class="' . esc_attr( $this->widgetClasses( $instance ) ) . ' nojs">';
 		echo '<h2 id="searchtabsheader" class="sr">Search the MIT libraries</h2>
 			<ul id="search_tabs_nav" aria-labelledby="searchtabsheader">
-			<li><a id="tab-all" href="#search-all"><span>All</span></a></li>
-			<li><a id="tab-books" href="#search-books"><span>Books + media</span></a></li>
-			<li><a id="tab-articles" href="#search-articles"><span>Journals + articles</span></a></li>
-			<li><a id="tab-more" href="#search-more"><span>More...</span></a></li>
+				<li><a id="tab-all" href="#search-all"><span>All</span></a></li>
+				<li><a id="tab-books" href="#search-books"><span>Books + media</span></a></li>
+				<li><a id="tab-articles" href="#search-articles"><span>'
+				. esc_html( $articles_tab_name )
+				. '</span></a></li>
+				<li><a id="tab-more" href="#search-more"><span>More...</span></a></li>
 			</ul>';
 		echo '<div id="search-all" aria-labelledby="tab-all">';
-		include( 'templates/tab-all.php' );
+			include( $all_template );
 		echo '</div>';
 		echo '<div id="search-books" aria-labelledby="tab-books">';
-		include( 'templates/tab-books.php' );
+			include( $books_template );
 		echo '</div>';
 		echo '<div id="search-articles" aria-labelledby="tab-articles">';
-		include( 'templates/tab-articles.php' );
+			include( $articles_template );
 		echo '</div>';
 		echo '<div id="search-more" aria-labelledby="tab-more">';
-		include( 'templates/tab-more.php' );
+			include( $more_template );
 		echo '</div>';
 		if ( $instance['banner_text'] ) {
 			$allowed = array(
@@ -170,6 +186,14 @@ class Multisearch_Widget extends \WP_Widget {
 		$ga_property = $instance['ga_property'];
 		$banner_text = $instance['banner_text'];
 		$linked_domains = $instance['linked_domains'];
+		$targets = $instance['targets'];
+		if ( '' == $instance['targets'] ) {
+			$targets = 'eds';
+		}
+		$bento_url = $instance['bento_url'];
+		if ( '' == $instance['bento_url'] ) {
+			$bento_url = 'https://lib.mit.edu/';
+		}
 		?>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'ga_property' ) ); ?>">
@@ -206,6 +230,50 @@ class Multisearch_Widget extends \WP_Widget {
 				echo esc_html( $banner_text );
 			?></textarea>
 		</p>
+		<p>Which set of search targets should be shown?</p>
+		<ul>
+			<li>
+				<label>
+					<input
+						type="radio"
+						name="<?php echo esc_attr( $this->get_field_name( 'targets' ) ); ?>"
+						value="eds"
+						<?php
+						if ( 'eds' == $targets ) {
+							echo "checked='checked'";
+						}
+						?>
+					>
+					EDS and Barton
+				</label>
+			</li>
+			<li>
+				<label>
+					<input
+						type="radio"
+						name="<?php echo esc_attr( $this->get_field_name( 'targets' ) ); ?>"
+						value="alma"
+						<?php
+						if ( 'alma' == $targets ) {
+							echo "checked='checked'";
+						}
+						?>
+					>
+					Alma and Primo
+				</label>
+			</li>
+		</ul>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'bento_url' ) ); ?>">
+				<?php esc_attr_e( 'Bento URL' ); ?> (formatted like "https://lib.mit.edu/")
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo esc_attr( $this->get_field_id( 'bento_url' ) ); ?>"
+				type="text"
+				name="<?php echo esc_attr( $this->get_field_name( 'bento_url' ) ); ?>"
+				value="<?php echo esc_html( $bento_url ); ?>">
+		</p>
 		<?php
 	}
 
@@ -222,6 +290,8 @@ class Multisearch_Widget extends \WP_Widget {
 		$instance['ga_property'] = $new_instance['ga_property'];
 		$instance['banner_text'] = $new_instance['banner_text'];
 		$instance['linked_domains'] = $new_instance['linked_domains'];
+		$instance['targets'] = $new_instance['targets'];
+		$instance['bento_url'] = $new_instance['bento_url'];
 		return $instance;
 	}
 

--- a/templates/tab-all-alma.php
+++ b/templates/tab-all-alma.php
@@ -29,5 +29,5 @@
 	</div>
 </form>
 <p class="also search-all">
-	<a href="https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en">Jump to Primo search</a>
+	<a href="/search-advanced/">Advanced search</a>
 </p>

--- a/templates/tab-all-alma.php
+++ b/templates/tab-all-alma.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The "Alma variant" of the search tab for all content - which will search the Bento app.
+ *
+ * @package Multisearch Widget
+ * @since 1.5.0
+ */
+
+?>
+<h3 class="sr">All panel</h3>
+<form
+	class="form search-bento"
+	action="<?php echo esc_url( $instance['bento_url'] ); ?>search/bento"
+	method="get"
+	data-target="bento">
+	<label for="searchinput-bento">Search the libraries</label>
+	<div class="wrap-flex">
+		<div class="flex-left">
+			<input
+				class="field field-text"
+				type="text"
+				id="searchinput-bento"
+				name="q"
+				placeholder="ex. artificial intelligence, journal of heat transfer, jstor, dresselhaus">
+		</div>
+		<div class="flex-right">
+			<input class="button button-search" type="submit" value="Search">
+		</div>
+	</div>
+</form>
+<p class="also search-all">
+	<a href="https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en">Jump to Primo search</a>
+</p>

--- a/templates/tab-all-eds.php
+++ b/templates/tab-all-eds.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The search tab for all content - which will search the Bento app.
+ * The "EDS variant" of the search tab for all content - which will search the Bento app.
  *
  * @package Multisearch Widget
  * @since 0.2.0

--- a/templates/tab-articles-alma.php
+++ b/templates/tab-articles-alma.php
@@ -20,7 +20,7 @@
 	<div class="hidden">
 		<input type="hidden" name="vid" value="01MIT_INST:MIT">
 		<input type="hidden" name="tab" value="all">
-		<input type="hidden" name="search_scope" value="all">
+		<input type="hidden" name="search_scope" value="cdi">
 		<input type="hidden" name="lang" value="en">
 		<input type="hidden" name="query" id="primoQuery">
 	</div>
@@ -56,9 +56,9 @@
 			// keyword, title, and author searching. So we assemble the search 
 			// string on submit.
 			var searchtype = 'any';
-			if ( this.limit.value == 'TI' ) {
+			if ( this.limit.value.trim() == 'TI' ) {
 				searchtype = 'title';
-			} else if ( this.limit.value == 'AU' ) {
+			} else if ( this.limit.value.trim() == 'AU' ) {
 				searchtype = 'creator';
 			}
 			this.query.value = searchtype + ",contains," + this.search.value.replace(/[,]/g, " ");
@@ -68,6 +68,6 @@
 	});
 </script>
 <p class="also">Also search for:
-	<a href="https://mit.primo.exlibrisgroup.com/discovery/jsearch?vid=01MIT_INST:MIT">Journals</a> or
-	<a href="https://mit.primo.exlibrisgroup.com/discovery/dbsearch?vid=01MIT_INST:MIT">Databases</a>
+	<a href="/search-journals/">Journals</a> or
+	<a href="/search-databases/">Databases</a>
 </p>

--- a/templates/tab-articles-alma.php
+++ b/templates/tab-articles-alma.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * The "Alma variant" of the search tab for articles and chapters. All
+ * searches are sent to Primo, with the querystring updated based on user
+ * choices.
+ *
+ * @package Multisearch Widget
+ * @since 1.5.0
+ */
+
+?>
+<h3 class="sr">Articles and chapters panel</h3>
+<form
+	class="form search-articles"
+	action="https://mit.primo.exlibrisgroup.com/discovery/search"
+	enctype="application/x-www-form-urlencoded; charset=utf-8"
+	id="primosearch"
+	method="get"
+	data-target="eds">
+	<div class="hidden">
+		<input type="hidden" name="vid" value="01MIT_INST:MIT">
+		<input type="hidden" name="tab" value="all">
+		<input type="hidden" name="search_scope" value="all">
+		<input type="hidden" name="lang" value="en">
+		<input type="hidden" name="query" id="primoQuery">
+	</div>
+	<label for="searchinput-article">Search journals and articles</label>
+	<div class="wrap-flex">
+		<div class="flex-left">
+			<div class="flex-left-inner">
+				<input 
+					class="field field-text" 
+					type="text" 
+					id="searchinput-article" 
+					name="search" 
+					placeholder="ex. game theory for control of optical networks, artificial intelligence, dresselhaus">
+				<div class="field-wrap-select">
+					<label class="sr" for="searchlimit-articles">limit to</label>
+					<select class="field field-select" name="limit" id="searchlimit-articles">
+						<option value="">Keyword</option>
+						<option value="TI ">Title</option>
+						<option value="AU ">Author</option>
+					</select>
+				</div>
+			</div>
+		</div>
+		<div class="flex-right">
+			<input class="button button-search" type="submit" value="Search">
+		</div>
+	</div>
+</form>
+<script type="text/javascript">
+	jQuery( document ).ready( function() {
+		jQuery( 'form#primosearch' ).on( 'submit', function() {
+			// Primo uses comma-separated-values to influence search behavior for
+			// keyword, title, and author searching. So we assemble the search 
+			// string on submit.
+			var searchtype = 'any';
+			if ( this.limit.value == 'TI' ) {
+				searchtype = 'title';
+			} else if ( this.limit.value == 'AU' ) {
+				searchtype = 'creator';
+			}
+			this.query.value = searchtype + ",contains," + this.search.value.replace(/[,]/g, " ");
+
+			return true;
+		});
+	});
+</script>
+<p class="also">Also search for:
+	<a href="https://mit.primo.exlibrisgroup.com/discovery/jsearch?vid=01MIT_INST:MIT">Journals</a> or
+	<a href="https://mit.primo.exlibrisgroup.com/discovery/dbsearch?vid=01MIT_INST:MIT">Databases</a>
+</p>

--- a/templates/tab-articles-eds.php
+++ b/templates/tab-articles-eds.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * The search tab for journals and articles - which will switch between EDS
- * and Vera forms as the user changes the input[name=target] control.
+ * The "EDS variant" of the search tab for journals and articles - which will
+ * switch between EDS and Vera forms as the user changes the
+ * input[name=target] control.
  *
  * @package Multisearch Widget
  * @since 0.2.0
@@ -9,7 +10,12 @@
 
 ?>
 <h3 class="sr">Journals and Articles panel</h3>
-<form class="form search-articles" action="https://widgets.ebscohost.com/prod/search/" id="edssearch" method="get" data-target="eds">
+<form
+	class="form search-articles"
+	action="https://widgets.ebscohost.com/prod/search/"
+	id="edssearch"
+	method="get"
+	data-target="eds">
 	<div class="hidden">
 		<input name="direct" value="true" type="hidden">
 		<input name="authtype" value="ip,guest" type="hidden">

--- a/templates/tab-books-alma.php
+++ b/templates/tab-books-alma.php
@@ -54,8 +54,8 @@
 	</div>
 </form>
 <p class="also">Also search for:
-	<a href="/theses">MIT theses</a> or
-	<a href="/reserves">Course reserves</a>
+	<a href="/search-mit-theses/">MIT theses</a> or
+	<a href="/search-reserves/">Course reserves</a>
 </p>
 <script type="text/javascript">
 function setPrimoSearch(form) {
@@ -67,7 +67,7 @@ function setPrimoSearch(form) {
 		.empty()
 		.append('<input name="vid" value="01MIT_INST:MIT" type="hidden">')
 		.append('<input name="tab" value="all" type="hidden">')
-		.append('<input name="search_scope" value="all" type="hidden">')
+		.append('<input name="search_scope" value="catalog" type="hidden">')
 		.append('<input name="lang" value="en" type="hidden">')
 		.append('<input name="query" type="hidden">');
 

--- a/templates/tab-books-alma.php
+++ b/templates/tab-books-alma.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * The "Alma variant" of the search tab for books and media - which will
+ * switch between Primo and Worldcat forms as the user changes the
+ * input[name=target] control.
+ *
+ * @package Multisearch Widget
+ * @since 1.5.0
+ */
+
+?>
+<h3 class="sr">Books and media panel</h3>
+<form
+	action=""
+	id="booksearch"
+	method="get"
+	class="form search-bookslocal">
+	<div class="hidden"></div>
+	<label for="searchinput-bookslocal">Search for books, ebooks, journals, databases, music, and videos</label>
+	<div class="wrap-flex">
+		<div class="flex-left">
+			<div class="flex-left-inner">
+				<input
+					class="field field-text"
+					id="searchinput-bookslocal"
+					name="search"
+					placeholder="ex. artificial intelligence, journal of heat transfer, jstor, dresselhaus"
+					type="text">
+				<div class="field-wrap-select">
+					<label class="sr" for="searchlimit-bookslocal">limit to</label>
+					<select class="field field-select" id="searchlimit-bookslocal" name="limit">
+						<option value="">Keyword</option>
+						<option value="TI">Title</option>
+						<option value="AU">Author</option>
+					</select>
+				</div>
+			</div>
+			<ul id="books-target" class="select-books-target">
+				<li>
+					<label>
+						<input type="radio" name="books-target" value="localbooks" checked="checked">at MIT
+					</label>
+				</li>
+				<li>
+					<label>
+						<input type="radio" name="books-target" value="worldcat">libraries worldwide (WorldCat)
+					</label>
+				</li>
+			</ul>
+		</div>
+		<div class="flex-right">
+			<input class="button button-search" type="submit" value="Search">
+		</div>
+	</div>
+</form>
+<p class="also">Also search for:
+	<a href="/theses">MIT theses</a> or
+	<a href="/reserves">Course reserves</a>
+</p>
+<script type="text/javascript">
+function setPrimoSearch(form) {
+	// Set action
+	form.action = 'https://mit.primo.exlibrisgroup.com/discovery/search';
+
+	// Load hidden fields
+	jQuery(form).find(".hidden")
+		.empty()
+		.append('<input name="vid" value="01MIT_INST:MIT" type="hidden">')
+		.append('<input name="tab" value="all" type="hidden">')
+		.append('<input name="search_scope" value="all" type="hidden">')
+		.append('<input name="lang" value="en" type="hidden">')
+		.append('<input name="query" type="hidden">');
+
+	// Build search field
+	var searchtype = 'any';
+	if ( form.limit.value == 'TI' ) {
+		searchtype = 'title';
+	} else if ( form.limit.value == 'AU' ) {
+		searchtype = 'creator';
+	}
+	form.query.value = searchtype + ",contains," + form.search.value.replace(/[,]/g, " ");
+}
+
+function setWorldcatSearch(form) {
+	// Set action
+	form.action = 'https://mit.on.worldcat.org/search';
+
+	// Load hidden fields
+	jQuery(form).find(".hidden")
+		.empty()
+		.append('<input type="hidden" name="queryString">');
+
+	// Transfer search string to actual field
+	form.queryString.value = form.search.value.trim();
+
+	// Build search field with title/author syntax
+	if ( form.limit.value !== '' ) {
+		form.queryString.value = form.limit.value.toLowerCase() + ':(' + form.queryString.value + ')';
+	}
+}
+
+jQuery( document ).ready( function() {
+	// Watch for form submissions
+	jQuery( 'form#booksearch' ).on( 'submit', function(event) {
+		// Read state of target
+		var target = jQuery("#books-target input[name=books-target]:checked").val();
+
+		if ( 'worldcat' === target ) {
+			setWorldcatSearch(this);
+		} else {
+			setPrimoSearch(this);
+		}
+	});
+});
+</script>

--- a/templates/tab-books-eds.php
+++ b/templates/tab-books-eds.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * The search tab for books and media - which will switch between Barton and
- * Worldcat forms as the user changes the input[name=target] control.
+ * The "EDS variant" of the search tab for books and media - which will switch
+ * between Barton and Worldcat forms as the user changes the
+ * input[name=target] control.
  *
  * @package Multisearch Widget
  * @since 0.2.0

--- a/templates/tab-more-alma.php
+++ b/templates/tab-more-alma.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The "Alma variant" of the search tab for "more" content - which will
+ * search the Google custom engine.
+ *
+ * @package Multisearch Widget
+ * @since 1.5.0
+ */
+
+?>
+<h3 class="sr">More panel</h3>
+<div class="wrap-3cols">
+	<div class="col col-1">
+		<h3 class="header-col">Looking for something else?</h3>
+		<ul>
+			<li><a href="/reserves">Course reserves</a></li>
+			<li><a href="/theses">MIT theses</a></li>
+			<li><a href="https://dspace.mit.edu">DSpace@MIT</a></li>
+			<li><a href="https://archivesspace.mit.edu/">ArchivesSpace</a></li>
+			<li><a href="http://libraries.mit.edu/experts/">Search tools by subject</a></li>
+			<li><a href="/search">More search options: images, data, etc.</a></li>
+		</ul>
+	</div>
+	<div class="col col-2">
+		<h3 class="header-col">Other useful tools</h3>
+		<ul>
+			<li><a href="https://libraries.mit.edu/worldcat">WorldCat</a></li>
+			<li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT</a></li>
+		</ul>
+	</div>
+	<div class="col col-3">
+		<h3 class="sr">Get help from a librarian</h3>
+		<p class="wrap-askus">
+			<a class="askus-link" href="https://libraries.mit.edu/ask">
+				<span class="askus-name">Ask Us</span> 
+				<span class="askus-desc">chat and email</span>
+			</a>
+		</p>
+	</div>
+</div>
+<form class="form search-site" action="https://www.google.com/cse" method="get" data-target="google">
+	<input type="hidden" name="cx" value="016240528703941589557:i7wrbu9cdxu">
+	<input type="hidden" name="ie" value="UTF-8">
+	<h3><label for="searchinput-site">Search the library website</label></h3>
+	<div class="wrap-flex">
+		<div class="flex-left">
+			<input id="searchinput-site" class="field field-text" type="text" name="q" placeholder="ex. hours">
+		</div>
+		<div class="flex-right">
+			<input type="submit" class="button button-search" name="sa" value="Search">
+		</div>
+	</div>
+</form>

--- a/templates/tab-more-eds.php
+++ b/templates/tab-more-eds.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * The search tab for "more" content - which will search the Google custom engine.
+ * The "EDS variant" of the search tab for "more" content - which will search
+ * the Google custom engine.
  *
  * @package Multisearch Widget
  * @since 0.2.0

--- a/wp-multisearch-widget.css
+++ b/wp-multisearch-widget.css
@@ -4,6 +4,11 @@
 #multisearch.wrap-search {
 	color: #111;	
 }
+#search-all a,
+#search-books a,
+#search-articles a {
+	text-decoration: underline;
+}
 .wrap-search, 
 .r-tabs {
 	background-color: #333;

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.4.1
+ * Version: 1.5.0
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?

This adds an option for the search widget to be converted between sending traffic to EDS and Barton (our current discovery tools), or to Alma and Primo (which are launching later this summer).

Additionally, the new templates have a configuration option to define which URL should be used for the Bento search - which will allow our staging site to use the staging bento, while production stays on the production bento.

To keep things clear, the existing templates have been renamed to use a "-eds" suffix, while the new templates have an "-alma" suffix.

#### Helpful background context (if appropriate)

After Alma and Primo have launched, and we don't need the EDS configuration any further, we'll need a second PR to remove those templates. At that point we can also remove some of the analytics-focused JS code that hasn't been ported over to Matomo.

#### How can a reviewer manually see the effects of these changes?

This update has been deployed to the staging site. I've left the plugin in the current (EDS) mode, but testers are welcome to switch over to Alma or staging bento as needed.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IMP-1774

#### Screenshots (if appropriate)

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
