### PR TITLE
Updates link to Databases A-Z on articles tab

### DIFF
--- a/templates/tab-articles-alma.php
+++ b/templates/tab-articles-alma.php
@@ -71,5 +71,5 @@
 </script>
 <p class="also">Also search for:
 	<a href="/search-journals/">Journals</a> or
-	<a href="/search-databases/">Databases</a>
+	<a href="https://libguides.mit.edu/az.php">Databases A-Z</a>
 </p>

--- a/wp-multisearch-widget.php
+++ b/wp-multisearch-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: Multisearch Widget
  * Plugin URI: https://github.com/MITLibraries/wp-multisearch-widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.6.0
+ * Version: 1.6.1
  * Author: MIT Libraries
  * Author URI: https://github.com/MITLibraries
  * License: GPL2


### PR DESCRIPTION
#### Why are these changes being introduced:

* The Libraries have rebuilt the Databases A-Z resource on LibGuides,
  and we want to point a link in on the articles tab to that location.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1377

#### How does this address that need:

* This updates the link in the footer of the articles tab to the new A-Z
  resource.

#### Document any side effects to this change:

* The plugin version is getting bumped to 1.6.1.

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
